### PR TITLE
CODE RUB: Adding Unknown enum value to TeacherGenderView enum

### DIFF
--- a/OtripleS.Portal.Web/Models/TeacherViews/TeacherGenderView.cs
+++ b/OtripleS.Portal.Web/Models/TeacherViews/TeacherGenderView.cs
@@ -9,6 +9,7 @@ namespace OtripleS.Portal.Web.Models.TeacherViews
     {
         Female,
         Male,
-        Other
+        Other,
+        Unknown
     }
 }


### PR DESCRIPTION
Due to discrepancies between TeacherGenderView enum and TeacherGender enum, `Unknown` value from Teacher was mapped to `3` in TeacherView.

Before:
![image](https://user-images.githubusercontent.com/35398078/140820407-f16e4d94-c843-4c7b-9a47-e64a347ee5af.png)

After:
![image](https://user-images.githubusercontent.com/35398078/140820520-6adf478b-a0d0-48fc-843f-c3eb78f06028.png)
